### PR TITLE
Fix async for issue #27

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ tmp*
 tst
 .*
 package.tar.gz
-documentation.yml
+karma.*
 
 # Logs
 logs

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -12,6 +12,8 @@ const ERRORS = Symbol('cache of all errors as they occurred during validation')
 const REFS = Symbol('cache of all referenced schemas in current schema')
 
 // "private" methods
+const VALIDATE = Symbol('validates schema')
+
 const ASSIGN_SCHEMA = Symbol('assigns schema definitions to the class instance')
 const ASSIGN_REF = Symbol('assigns a ref to ref cache')
 const ASSIGN_REFS = Symbol('assigns a Hash of refs to ref cache')
@@ -43,11 +45,13 @@ class Schema {
       [REFS]: { value: {} }
     })
 
-    if (isAsync) {
-      Object.defineProperty(this, 'validate', {
-        value: async (data, schema) => super.validate(data, schema)
+    isAsync
+      ? Object.defineProperty(this, 'validate', {
+        value: async (data, schema) => this[VALIDATE](data, schema)
       })
-    }
+      : Object.defineProperty(this, 'validate', {
+        value: (data, schema) => this[VALIDATE](data, schema)
+      })
   }
 
   get errors () {
@@ -81,7 +85,7 @@ class Schema {
    * @param {Schema} [schema=this] - Optionally pass nested JSON Schema definitions of the instance for partial schema validation or other instances of the JSON Schema class.
    * @returns {boolean} <code>true</code> if validation is successful, otherwise <code>false</code>.
    */
-  validate (data, schema = this) {
+  [VALIDATE] (data, schema = this) {
     this[ERRORS].length = 0
 
     if (schema === false) this[ERRORS].push('\'false\' JSON Schema invalidates all values')

--- a/tst/functional/draft-04-optional.spec.js
+++ b/tst/functional/draft-04-optional.spec.js
@@ -11,15 +11,13 @@ import folderSchema from '../JSON-Schema-Test-Suite/remotes/folder/folderInteger
 describe('functional tests for draft-04 specification - optional', async () => {
   const draft4Optional = await getTests('./tst/JSON-Schema-Test-Suite/tests/draft4/optional', ['zeroTerminatedFloats.json'])
 
-  after(() => {
-    nock.cleanAll()
-    nock.enableNetConnect()
-  })
+  after(() => (nock.enableNetConnect()))
+
+  afterEach(() => (nock.cleanAll()))
+
+  before(() => (nock.disableNetConnect()))
 
   beforeEach(() => {
-    nock.cleanAll()
-    nock.disableNetConnect()
-
     nock('http://json-schema.org')
       .get('/draft-04/schema')
       .reply(200, draft04Schema)

--- a/tst/functional/draft-04.spec.js
+++ b/tst/functional/draft-04.spec.js
@@ -11,15 +11,13 @@ import folderSchema from '../JSON-Schema-Test-Suite/remotes/folder/folderInteger
 describe('functional tests for draft-04 specification', async () => {
   const draft4Tests = await getTests('./tst/JSON-Schema-Test-Suite/tests/draft4')
 
-  after(() => {
-    nock.cleanAll()
-    nock.enableNetConnect()
-  })
+  after(() => (nock.enableNetConnect()))
+
+  afterEach(() => (nock.cleanAll()))
+
+  before(() => (nock.disableNetConnect()))
 
   beforeEach(() => {
-    nock.cleanAll()
-    nock.disableNetConnect()
-
     nock('http://json-schema.org')
       .get('/draft-04/schema')
       .reply(200, draft04Schema)

--- a/tst/functional/draft-06-optional.spec.js
+++ b/tst/functional/draft-06-optional.spec.js
@@ -11,15 +11,13 @@ import folderSchema from '../JSON-Schema-Test-Suite/remotes/folder/folderInteger
 describe('functional tests for draft-06 specification - optional', async () => {
   const draft6Optional = await getTests('./tst/JSON-Schema-Test-Suite/tests/draft6/optional')
 
-  after(() => {
-    nock.cleanAll()
-    nock.enableNetConnect()
-  })
+  after(() => (nock.enableNetConnect()))
+
+  afterEach(() => (nock.cleanAll()))
+
+  before(() => (nock.disableNetConnect()))
 
   beforeEach(() => {
-    nock.cleanAll()
-    nock.disableNetConnect()
-
     nock('http://json-schema.org')
       .get('/draft-04/schema')
       .reply(200, draft04Schema)

--- a/tst/functional/draft-06.spec.js
+++ b/tst/functional/draft-06.spec.js
@@ -12,15 +12,13 @@ import folderSchema from '../JSON-Schema-Test-Suite/remotes/folder/folderInteger
 describe('functional tests for draft-06 specification', async () => {
   const draft6Tests = await getTests('./tst/JSON-Schema-Test-Suite/tests/draft6', ['boolean_schema.json'])
 
-  after(() => {
-    nock.cleanAll()
-    nock.enableNetConnect()
-  })
+  after(() => (nock.enableNetConnect()))
+
+  afterEach(() => (nock.cleanAll()))
+
+  before(() => (nock.disableNetConnect()))
 
   beforeEach(() => {
-    nock.cleanAll()
-    nock.disableNetConnect()
-
     nock('http://json-schema.org')
       .get('/draft-04/schema')
       .reply(200, draft04Schema)

--- a/tst/unit/Schema.spec.js
+++ b/tst/unit/Schema.spec.js
@@ -72,7 +72,12 @@ describe('Schema', () => {
       expect(schema.assign).to.be.a('function')
       expect(schema.validate).to.be.a('function')
 
-      expect(schema.validate(true)).to.eventually.be.ok()
+      expect(await schema.validate(true)).to.be.ok()
+
+      schema = await new Schema({ properties: { test: { type: 'string' }, another: { type: 'string' } } }, true)
+
+      expect(await schema.validate({ test: 'ing', another: 'object' })).to.be.ok()
+      expect(await schema.validate({ test: true, another: 'object' })).not.to.be.ok()
     })
   })
 

--- a/tst/unit/Schema.spec.js
+++ b/tst/unit/Schema.spec.js
@@ -3,6 +3,7 @@ import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import dirtyChai from 'dirty-chai'
 import nock from 'nock'
+import sinon from 'sinon'
 
 import Schema from '../../src/Schema'
 
@@ -13,12 +14,15 @@ chai.use(dirtyChai)
 
 describe('Schema', () => {
   const testSchema = { $id: 'http://json-schema.org/draft-04/schema', type: 'string' }
-  let endpoint, schema
+  let schema
 
-  afterEach(() => {
-    endpoint = null
-    schema = null
+  after(() => {
+    nock.enableNetConnect()
   })
+
+  afterEach(() => (schema = null))
+
+  before(() => (nock.disableNetConnect()))
 
   describe('constructor', () => {
     it('should create a Schema object successfully', async () => {
@@ -197,18 +201,20 @@ describe('Schema', () => {
   })
 
   describe('($)id|$ref keywords', () => {
-    after(() => {
+    afterEach(() => {
       nock.cleanAll()
-      nock.enableNetConnect()
+
+      if (global.fetch) global.fetch.restore()
     })
 
     beforeEach(() => {
-      nock.cleanAll()
-      nock.disableNetConnect()
-
-      endpoint = nock('http://json-schema.org')
+      nock('http://json-schema.org')
         .get('/draft-04/schema')
         .reply(200, testSchema)
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({ json: () => testSchema }))
+      }
     })
 
     it('should assign with simple definitions successfully', async () => {
@@ -247,7 +253,6 @@ describe('Schema', () => {
       schema = await new Schema(testSchema)
 
       expect(schema).to.deep.equal(testSchema)
-      expect(endpoint.isDone()).to.be.false()
     })
 
     it('should assign with nested subSchema successfully', async () => {
@@ -263,7 +268,6 @@ describe('Schema', () => {
       schema = await new Schema(test, refs)
 
       expect(schema).to.deep.equal(test)
-      expect(endpoint.isDone()).to.be.false()
     })
 
     it('should assign nested path fragments successfully', async () => {

--- a/tst/unit/utils/index.spec.js
+++ b/tst/unit/utils/index.spec.js
@@ -2,6 +2,7 @@
 import chai, { expect } from 'chai'
 import dirtyChai from 'dirty-chai'
 import nock from 'nock'
+import sinon from 'sinon'
 
 import { getSchema } from '../../../src/utils'
 import draft04Schema from '../../refs/json-schema-draft-04.json'
@@ -9,25 +10,29 @@ import draft04Schema from '../../refs/json-schema-draft-04.json'
 chai.use(dirtyChai)
 
 describe('getSchema', () => {
-  let endpoint
-
   after(() => {
-    nock.cleanAll()
     nock.enableNetConnect()
   })
 
-  afterEach(() => {
-    endpoint = null
+  before(() => {
+    nock.disableNetConnect()
   })
 
   context('from http endpoints', () => {
-    beforeEach(() => {
+    afterEach(() => {
       nock.cleanAll()
-      nock.disableNetConnect()
 
-      endpoint = nock('http://json-schema.org')
+      if (global.fetch) global.fetch.restore()
+    })
+
+    beforeEach(() => {
+      nock('http://json-schema.org')
         .get('/draft-04/schema')
         .reply(200, draft04Schema)
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({ json: () => draft04Schema }))
+      }
     })
 
     it('should request the schema successfully', async () => {
@@ -35,65 +40,85 @@ describe('getSchema', () => {
     })
   })
 
-  // TODO fix this
-  // context('from https endpoints', () => {
-  //   beforeEach(() => {
-  //     nock.cleanAll()
-  //     nock.disableNetConnect()
-  //
-  //     endpoint = nock('https://json-schema.org')
-  //       .get('/draft-04/schema')
-  //       .reply(200, draft04Schema)
-  //   })
-  //
-  //   it('should request the schema successfully', async () => {
-  //     expect(await getSchema('https://json-schema.org/draft-04/schema')).to.deep.equal(draft04Schema)
-  //     expect(endpoint.isDone()).to.be.true()
-  //   })
-  // })
+  context('from https endpoints', () => {
+    afterEach(() => {
+      nock.cleanAll()
+
+      if (global.fetch) global.fetch.restore()
+    })
+
+    beforeEach(() => {
+      nock('https://json-schema.org')
+        .get('/draft-04/schema')
+        .reply(200, draft04Schema)
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({ json: () => draft04Schema }))
+      }
+    })
+
+    it('should request the schema successfully', async () => {
+      expect(await getSchema('https://json-schema.org/draft-04/schema')).to.deep.equal(draft04Schema)
+    })
+  })
 
   context('from endpoints that cause errors', () => {
-    beforeEach(() => {
+    afterEach(() => {
       nock.cleanAll()
-      nock.disableNetConnect()
+
+      if (global.fetch) global.fetch.restore()
     })
 
     it('should refuse to request anything other than a string', async () => {
-      endpoint = nock('http://json-schema.org')
+      nock('http://json-schema.org')
         .get('/draft-04/schema')
         .reply(200, {})
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({ json: () => ({}) }))
+      }
 
       try {
         await getSchema(null)
       } catch (e) {
         expect(e.message).to.equal('#getSchema: url must be a string')
-        expect(endpoint.isDone()).to.be.false()
       }
     })
 
+    // TODO: double check this is working right
     it('should expect to catch an error on 500 status code', async () => {
-      endpoint = nock('http://json-schema.org')
+      nock('http://json-schema.org')
         .get('/draft-04/schema')
         .reply(500, {})
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({
+          json: () => {
+            throw new Error('Request Failed.\nStatus Code: 500')
+          }
+        }))
+      }
 
       try {
         await getSchema('http://json-schema.org/draft-04/schema', false)
       } catch (e) {
         expect(e.message).to.equal('Request Failed.\nStatus Code: 500')
-        expect(endpoint.isDone()).to.be.true()
       }
     })
 
-    it('should expect to catch an error on 500 status code', async () => {
-      endpoint = nock('http://json-schema.org')
+    it('should expect to catch an error on invalid content type', async () => {
+      nock('http://json-schema.org')
         .get('/draft-04/schema')
         .reply(200, undefined)
+
+      if (global.fetch) {
+        sinon.stub(global, 'fetch').callsFake(async () => Promise.resolve({ json: () => undefined }))
+      }
 
       try {
         await getSchema('http://json-schema.org/draft-04/schema', false)
       } catch (e) {
         expect(e.message).to.equal('Invalid content-type.\nExpected application/json but received undefined')
-        expect(endpoint.isDone()).to.be.true()
       }
     })
   })


### PR DESCRIPTION
I've refactored async validatation by making the main `validate` method private and attaching either an `async` or normal function when the Schema is created. Resolves https://github.com/fnalabs/schema-json-js/issues/27.